### PR TITLE
Fix branch name in CI/CD

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,7 +3,7 @@ name: CI/CD
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
 
 jobs:
   genVer:  # Generates a semantic versioning number to apply to docker image and nodejs package


### PR DESCRIPTION
Fixed the CI/CD action to look at branch 'main' instead of 'master'
Only labeled 'major' because the previous major did not run, so version did not change