### PR TITLE
Fixed mobile hover effect bug

### DIFF
--- a/client/src/components/projects/project/project.scss
+++ b/client/src/components/projects/project/project.scss
@@ -26,6 +26,9 @@ $thumbnailZoom: scale(1.025);
 
         &:hover {
             transform: $thumbnailZoom;
+            @media #{$media-mobile} {
+                transform: none;
+            }
         }
     }
 
@@ -103,10 +106,6 @@ $thumbnailZoom: scale(1.025);
                 padding: 5% 5% 0;
 
             }
-        }
-
-        @media #{$media-mobile} {
-           
         }
         
         @media #{$media-mobile} {


### PR DESCRIPTION
On mobile devices, when "hovering" over a project, the project would still expand without the title box being the same size. Both remain the same size now